### PR TITLE
Post iter augmentation

### DIFF
--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -136,7 +136,7 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename):
     pcoord_ndim = plugin_config.get('pcoord_ndim', 1)
 
     model = msm_we.modelWE()
-    log.info('Preparing coordinates...')
+    log.info('Augmenting west.h5 with coordinates...')
 
     # Only need the model to get the number of iterations and atoms
     # TODO: Replace this with something more lightweight, get directly from WE
@@ -445,6 +445,10 @@ class RestartDriver:
 
         sim_manager.register_callback(sim_manager.finalize_run, self.prepare_new_we, self.priority)
 
+        # prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
+        prep_coord = lambda: prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
+        sim_manager.register_callback(sim_manager.post_propagation, prep_coord, 1)
+
         # Initialize data
         self.ss_alg = None
         self.ss_dist = None
@@ -714,8 +718,8 @@ class RestartDriver:
         if not os.path.exists(run_directory):
             os.makedirs(run_directory)
 
-        # Write coordinates to h5
-        prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
+        # # Write coordinates to h5
+        # prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
 
         for data_folder in ['traj_segs', 'seg_logs']:
             old_path = data_folder

--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -103,7 +103,7 @@ def fix_deprecated_initialization(initialization_state):
 
 # TODO: Break this out into a separate module, let it be specified (if it's necessary) as a plugin option
 #   This may not always be required -- i.e. you may be able to directly output to the h5 file in your propagator
-def prepare_coordinates(plugin_config, h5file, we_h5filename):
+def prepare_coordinates(plugin_config, h5file, we_h5filename, _iteration=None):
     """
     Copy relevant coordinates from trajectory files into <iteration>/auxdata/coord of the h5 file.
 
@@ -126,44 +126,34 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename):
     """
 
     refPDBfile = plugin_config.get('ref_pdb_file')
-    modelName = plugin_config.get('model_name')
 
     # TODO: Don't need this explicit option, use WEST_SIM_ROOT or something
     WEfolder = plugin_config.get('we_folder')
 
     parentTraj = plugin_config.get('parent_traj_filename')
     childTraj = plugin_config.get('child_traj_filename')
-    pcoord_ndim = plugin_config.get('pcoord_ndim', 1)
 
-    model = msm_we.modelWE()
-    # log.info('Augmenting west.h5 with coordinates...')
-    westpa.rc.pstatus('Augmenting west.h5 with coordinates...')
+    reference_structure = md.load(refPDBfile)
 
-    # Only need the model to get the number of iterations and atoms
-    # TODO: Replace this with something more lightweight, get directly from WE
-    log.debug(f'Doing collectCoordinates on  WE file {we_h5filename}')
-    model.initialize(
-        [we_h5filename],
-        refPDBfile,
-        modelName,
-        # Pass some dummy arguments -- these aren't important, this model is just created for convenience
-        # in the coordinate collection. Dummy arguments prevent warnings from being raised.
-        basis_pcoord_bounds=None,
-        target_pcoord_bounds=None,
-        tau=1,
-        pcoord_ndim=pcoord_ndim,
-        _suppress_boundary_warning=True,
-    )
-    model.get_iterations()
+    westpa.rc.pstatus(f"Processing for iter {_iteration}")
 
-    log.debug(f"Found {model.maxIter} iterations")
+    if _iteration is not None:
+        # Get the number of iterations, according to the _iteration argument
+        _iters = range(1, _iteration + 1)
+    else:
+        # Get the number of iterations from the H5 file
+        # Here we're not end-inclusive (no +1), because in general if you call this after a WE run, the
+        #   iteration is max_iter+1.
+        #   I.e., a WESTPA run with 20 iterations will finish on iteration 21, which has no dynamics.
+        _iters = range(1, h5file.attrs['west_current_iteration'])
 
-    n_iter = None
-    # for n_iter in tqdm.tqdm(range(1, model.maxIter + 1)):
-    for n_iter in range(1, model.maxIter + 1):
+    # for n_iter in range(1, model.maxIter + 1):
+    for n_iter in _iters:
 
-        nS = model.numSegments[n_iter - 1].astype(int)
-        coords = np.zeros((nS, 2, model.nAtoms, 3))
+        # TODO: Take the template string from west.cfg, not guaranteed to be 8 digits
+        nS = len(h5file[f'iterations/iter_{n_iter:08d}/seg_index'])
+        coords = np.zeros((nS, 2, reference_structure.n_atoms, 3))
+
         dsetName = "/iterations/iter_%08d/auxdata/coord" % int(n_iter)
 
         coords_exist = False
@@ -174,16 +164,18 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename):
             coords_exist = True
             continue
 
+        westpa.rc.pstatus(f'Augmenting west.h5 with coordinates for iter {n_iter}')
+
         for iS in range(nS):
             trajpath = WEfolder + "/traj_segs/%06d/%06d" % (n_iter, iS)
 
             try:
-                coord0 = np.squeeze(md.load(f'{trajpath}/{parentTraj}', top=model.reference_structure.topology)._xyz)
+                coord0 = np.squeeze(md.load(f'{trajpath}/{parentTraj}', top=reference_structure.topology)._xyz)
             except OSError:
                 log.warning("Parent traj file doesn't exist, loading reference structure coords")
-                coord0 = np.squeeze(model.reference_structure._xyz)
+                coord0 = np.squeeze(reference_structure._xyz)
 
-            coord1 = np.squeeze(md.load(f'{trajpath}/{childTraj}', top=model.reference_structure.topology)._xyz)
+            coord1 = np.squeeze(md.load(f'{trajpath}/{childTraj}', top=reference_structure.topology)._xyz)
 
             coords[iS, 0, :, :] = coord0
             coords[iS, 1, :, :] = coord1
@@ -448,8 +440,11 @@ class RestartDriver:
         sim_manager.register_callback(sim_manager.finalize_run, self.prepare_new_we, self.priority)
 
         # prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
-        prep_coord = lambda: prepare_coordinates(self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename)
-        sim_manager.register_callback(sim_manager.post_propagation, prep_coord, 1)
+        prep_coord = lambda: prepare_coordinates(
+            self.plugin_config, self.data_manager.we_h5file, self.data_manager.we_h5filename, _iteration=self.cur_iter
+        )
+
+        sim_manager.register_callback(sim_manager.post_we, prep_coord, 1)
 
         # Initialize data
         self.ss_alg = None
@@ -483,9 +478,9 @@ class RestartDriver:
 
         Returns
         -------
-        int: The current iteration. Subtract one, because in finalize_run the iter has been incremented
+        int: The current iteration.
         """
-        return self.sim_manager.n_iter - 1
+        return self.sim_manager.n_iter
 
     @property
     def is_last_iteration(self):

--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -769,7 +769,7 @@ class RestartDriver:
 
             log.info(f"Run {restart_state['runs_completed']}/{self.n_runs} completed.")
 
-            # TODO: Initialize a new run, from the same configuration as this run was
+            # Initialize a new run, from the same configuration as this run was
             #   On the 1st run, I can write bstates/tstates/sstates into restart files, and use those for spawning
             #   subsequent runs in the marathon. That way, I don't make unnecessary copies of all those.
             # Basis and target states are unchanged. Can I get the original parameters passed to w_init?
@@ -860,10 +860,8 @@ class RestartDriver:
         self.data_manager.finalize_run()
         shutil.copyfile(self.data_manager.we_h5filename, f"{run_directory}/west.h5")
 
-        # Use all files in all restarts
         # Restarts index at 0, because there's  a 0th restart before you've... restarted anything.
         # Runs index at 1, because Run 1 is the first run.
-        # TODO: Let the user pick last half or something in the plugin config.
         marathon_west_files = []
         # When doing the first restart, restarts_completed is 0 (because the first restart isn't complete yet) and
         #   the data generated during this restart is in /restart0.
@@ -984,6 +982,10 @@ class RestartDriver:
 
         # Construct start-state file with all structures and their weights
         # TODO: Don't explicitly write EVERY structure to disk, or this will be a nightmare for large runs.
+        # TODO: There are probably multiple better ways of doing this -- one big flaw with this is I absolutely need
+        #   msm_we to have full access to all coordinates, because otherwise it can't write out these structures.
+        #   If I instead "write" the structures by looking at the corresponding trajectory file, then I don't need
+        #   all those atomic coordinates in west.h5.... but then I can't tar up all the trajectory files. Neither great.
         # However, for now, it's fine...
         log.debug("Writing structures")
         # TODO: Include start states from previous runs

--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -135,8 +135,6 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename, _iteration=None):
 
     reference_structure = md.load(refPDBfile)
 
-    westpa.rc.pstatus(f"Processing for iter {_iteration}")
-
     if _iteration is not None:
         # Get the number of iterations, according to the _iteration argument
         _iters = range(1, _iteration + 1)
@@ -145,9 +143,10 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename, _iteration=None):
         # Here we're not end-inclusive (no +1), because in general if you call this after a WE run, the
         #   iteration is max_iter+1.
         #   I.e., a WESTPA run with 20 iterations will finish on iteration 21, which has no dynamics.
+        # Might be able to use this by default, instead of needing _iteration, but feels safer to get it straight from
+        #   the sim manager when possible.
         _iters = range(1, h5file.attrs['west_current_iteration'])
 
-    # for n_iter in range(1, model.maxIter + 1):
     for n_iter in _iters:
 
         # TODO: Take the template string from west.cfg, not guaranteed to be 8 digits

--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -136,7 +136,8 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename):
     pcoord_ndim = plugin_config.get('pcoord_ndim', 1)
 
     model = msm_we.modelWE()
-    log.info('Augmenting west.h5 with coordinates...')
+    # log.info('Augmenting west.h5 with coordinates...')
+    westpa.rc.pstatus('Augmenting west.h5 with coordinates...')
 
     # Only need the model to get the number of iterations and atoms
     # TODO: Replace this with something more lightweight, get directly from WE
@@ -158,7 +159,8 @@ def prepare_coordinates(plugin_config, h5file, we_h5filename):
     log.debug(f"Found {model.maxIter} iterations")
 
     n_iter = None
-    for n_iter in tqdm.tqdm(range(1, model.maxIter + 1)):
+    # for n_iter in tqdm.tqdm(range(1, model.maxIter + 1)):
+    for n_iter in range(1, model.maxIter + 1):
 
         nS = model.numSegments[n_iter - 1].astype(int)
         coords = np.zeros((nS, 2, model.nAtoms, 3))


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** 
Moves west.h5 atomic coordinate augmentation from post-run to post-iteration


**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
Enable post-run tarring of trajectory files by removing the need to have all iteration atomic coordinates available at the end of a run.
By processing the atomic coordinates on the fly, the simulation is both more robust to failure (partial coordinates will still be augmented) and flexible to common data-management techniques like tarring and deleting traj_segs.

**Major files changed.**  
- haMSM restart driver

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.**
Because of the large numbers of files WESTPA may generate, it's common practice to want to clean up your generated `traj_segs`. Otherwise, both disk usage and inode usage can skyrocket. 
That's typically done with a `post-iter.sh` script, which was not compatible with haMSM restarting before this PR
