### PR TITLE
Hdf5 framework formatting

### DIFF
--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -605,27 +605,19 @@ class WESTDataManager:
             n_dims = 3
             n_frames = steps_per_seg * n_segments
 
-            iter_layout = h5py.VirtualLayout(
-                shape=(n_segments, steps_per_seg, n_atoms, n_dims),
-                dtype='<f4')
+            iter_layout = h5py.VirtualLayout(shape=(n_segments, steps_per_seg, n_atoms, n_dims), dtype='<f4')
 
-            iter_vsource = h5py.VirtualSource(
-                '.',
-                '/coordinates',
-                shape=(n_frames, n_atoms, n_dims)
-            )
+            iter_vsource = h5py.VirtualSource('.', '/coordinates', shape=(n_frames, n_atoms, n_dims))
 
-            n_remaining_segments = n_segments-1
+            n_remaining_segments = n_segments - 1
 
             for i, segment in enumerate(segments):
 
                 segment_index = segment.seg_id
-                source_index = h5_trajectory_pointers[i*steps_per_seg, 1]
+                source_index = h5_trajectory_pointers[i * steps_per_seg, 1]
 
                 # A layout can be populated from a source file that doesn't exist yet
-                iter_layout[segment_index] = iter_vsource[
-                        source_index * steps_per_seg:(source_index + 1) * steps_per_seg
-                    ]
+                iter_layout[segment_index] = iter_vsource[source_index * steps_per_seg : (source_index + 1) * steps_per_seg]
                 n_remaining_segments -= 1
 
             # This logic looks a little weird, given the loop above.
@@ -640,11 +632,7 @@ class WESTDataManager:
 
                 # If all the segments have been processed, create the virtual dataset of sorted segments
                 with h5py.File(iter_ref_h5_file, 'a') as outf:
-                    outf.create_virtual_dataset(
-                        '/sorted_segment_trajectories',
-                        iter_layout,
-                        fillvalue=-1
-                    )
+                    outf.create_virtual_dataset('/sorted_segment_trajectories', iter_layout, fillvalue=-1)
 
     def get_basis_states(self, n_iter=None):
         '''Return a list of BasisState objects representing the basis states that are in use for iteration n_iter.'''

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -577,8 +577,10 @@ class WESTDataManager:
             for segment in segments:
                 outf.write_segment(segment, True)
 
-            # Don't need this on the first iteration (and it's not defined then)
-            if n_iter > 0:
+            # Don't need this on the first iteration (and it's not defined then).
+            # This topology may be undefined in other circumstances too (like after a pcoord update, apparently),
+            #   so check that explicitly instead of checking the iteration.
+            if outf.topology is not None:
                 n_atoms = outf.topology.n_atoms
                 h5_trajectory_pointers = outf.read_data('/', 'pointer')
 

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -575,8 +575,11 @@ class WESTDataManager:
         # This function is run both in propagation and in we
         with h5io.WESTIterationFile(iter_ref_h5_file, 'a') as outf:
             for segment in segments:
-                # print(f"Writing segment with id {segment.seg_id} {segment}")
                 outf.write_segment(segment, True)
+
+            # Don't need this on the first iteration (and it's not defined then)
+            if n_iter > 0:
+                n_atoms = outf.topology.n_atoms
 
         iter_group = self.get_iter_group(n_iter)
 
@@ -584,55 +587,43 @@ class WESTDataManager:
             # print(f"trajectories not found in {iter_group.keys()} at iter {n_iter}")
 
             if n_iter == 0:
+                # For the ibstates in iter 0, just link to the ibstates iteration H5 file.
+                # TODO: These aren't written correctly for SynD
                 iter_group['trajectories'] = h5py.ExternalLink(iter_ref_rel_path, '/')
                 return
 
             # TODO: Deal with this sizing in a better way!!! This is just for testing
             n_segments = self.get_iter_summary()[0]
             steps_per_seg = westpa.rc.config.get(['west', 'system', 'system_options', 'pcoord_len'])-1
-            # n_atoms = 4010 # NaCl
-            n_atoms = 272 # Trp-cage
             n_dims = 3
             n_frames = steps_per_seg * n_segments
-            # print(f"N segs: {n_segments}, steps per: {steps_per_seg}, n_frames: {n_frames}")
 
-            self.iter_layout = h5py.VirtualLayout(
+            iter_layout = h5py.VirtualLayout(
                 shape=(n_segments, steps_per_seg, n_atoms, n_dims),
                 dtype='<f4')
 
-            self.iter_vsource = h5py.VirtualSource(
+            iter_vsource = h5py.VirtualSource(
                 iter_ref_rel_path,
                 '/coordinates',
                 shape=(n_frames, n_atoms, n_dims)
             )
 
-            # westpa.rc.pstatus(f"iter vsource is {iter_ref_rel_path}:/coordinates")
-            # westpa.rc.pstatus(f"Iter summary is {self.get_iter_summary()}")
-
-            # for i, segment in enumerate(segments):
             for i in range(n_segments):
 
                 segment_index = i
 
-                # westpa.rc.pstatus(f"Trying to place segment with id {segment_index}, length "
-                #                   f"{i * steps_per_seg}:{(i + 1) * steps_per_seg}")
-
                 # A layout can be populated from a source file that doesn't exist yet
                 # TODO: Use the pointer or something instead of i, so these are correctly ordered
                 #   according to ID.
-                self.iter_layout[segment_index] = self.iter_vsource[
+                iter_layout[segment_index] = iter_vsource[
                         i * steps_per_seg:(i + 1) * steps_per_seg
                     ]
 
-            # print(f"Creating virtual dataset at {iter_group.name}/trajectories/auxdata_virtual_coord")
             self.we_h5file.create_virtual_dataset(
                 f'{iter_group.name}/trajectories/auxdata_virtual_coord',
-                self.iter_layout,
+                iter_layout,
                 fillvalue=-1
             )
-
-
-            # iter_group['trajectories'] = h5py.ExternalLink(iter_ref_rel_path, '/')
 
     def get_basis_states(self, n_iter=None):
         '''Return a list of BasisState objects representing the basis states that are in use for iteration n_iter.'''

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -575,25 +575,26 @@ class WESTDataManager:
         # This function is run both in propagation and in we
         with h5io.WESTIterationFile(iter_ref_h5_file, 'a') as outf:
             for segment in segments:
-                print(f"Writing segment with id {segment.seg_id} {segment}")
+                # print(f"Writing segment with id {segment.seg_id} {segment}")
                 outf.write_segment(segment, True)
 
         iter_group = self.get_iter_group(n_iter)
 
         if 'trajectories' not in iter_group:
-            print(f"trajectories not found in {iter_group.keys()} at iter {n_iter}")
+            # print(f"trajectories not found in {iter_group.keys()} at iter {n_iter}")
 
             if n_iter == 0:
                 iter_group['trajectories'] = h5py.ExternalLink(iter_ref_rel_path, '/')
                 return
 
-            # TODO: Deal with this sizing in a better way
+            # TODO: Deal with this sizing in a better way!!! This is just for testing
             n_segments = self.get_iter_summary()[0]
             steps_per_seg = westpa.rc.config.get(['west', 'system', 'system_options', 'pcoord_len'])-1
-            n_atoms = 4010
+            # n_atoms = 4010 # NaCl
+            n_atoms = 272 # Trp-cage
             n_dims = 3
             n_frames = steps_per_seg * n_segments
-            print(f"N segs: {n_segments}, steps per: {steps_per_seg}, n_frames: {n_frames}")
+            # print(f"N segs: {n_segments}, steps per: {steps_per_seg}, n_frames: {n_frames}")
 
             self.iter_layout = h5py.VirtualLayout(
                 shape=(n_segments, steps_per_seg, n_atoms, n_dims),
@@ -605,16 +606,16 @@ class WESTDataManager:
                 shape=(n_frames, n_atoms, n_dims)
             )
 
-            westpa.rc.pstatus(f"iter vsource is {iter_ref_rel_path}:/coordinates")
-            westpa.rc.pstatus(f"Iter summary is {self.get_iter_summary()}")
+            # westpa.rc.pstatus(f"iter vsource is {iter_ref_rel_path}:/coordinates")
+            # westpa.rc.pstatus(f"Iter summary is {self.get_iter_summary()}")
 
             # for i, segment in enumerate(segments):
             for i in range(n_segments):
 
                 segment_index = i
 
-                westpa.rc.pstatus(f"Trying to place segment with id {segment_index}, length "
-                                  f"{i * steps_per_seg}:{(i + 1) * steps_per_seg}")
+                # westpa.rc.pstatus(f"Trying to place segment with id {segment_index}, length "
+                #                   f"{i * steps_per_seg}:{(i + 1) * steps_per_seg}")
 
                 # A layout can be populated from a source file that doesn't exist yet
                 # TODO: Use the pointer or something instead of i, so these are correctly ordered
@@ -623,7 +624,7 @@ class WESTDataManager:
                         i * steps_per_seg:(i + 1) * steps_per_seg
                     ]
 
-            print(f"Creating virtual dataset at {iter_group.name}/trajectories/auxdata_virtual_coord")
+            # print(f"Creating virtual dataset at {iter_group.name}/trajectories/auxdata_virtual_coord")
             self.we_h5file.create_virtual_dataset(
                 f'{iter_group.name}/trajectories/auxdata_virtual_coord',
                 self.iter_layout,
@@ -1218,8 +1219,12 @@ class WESTDataManager:
                     outf.read_restart(parent)
 
                 segment.data['iterh5/restart'] = parent.data['iterh5/restart']
+            except h5io.NoRestartError as e:
+                # Segment did not contain restart data
+                log.debug('No restart data provided for segment {}/{}: {}'.format(segment.n_iter, segment.seg_id, str(e)))
             except Exception as e:
-                print('could not prepare restart data for segment {}/{}: {}'.format(segment.n_iter, segment.seg_id, str(e)))
+                # Segment contained restart data, but there was a problem loading it
+                log.error('Error preparing restart data for segment {}/{}: {}'.format(segment.n_iter, segment.seg_id, str(e)))
 
     def get_all_parent_ids(self, n_iter):
         file_version = self.we_h5file_version

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -575,15 +575,18 @@ class WESTDataManager:
         # This function is run both in propagation and in we
         with h5io.WESTIterationFile(iter_ref_h5_file, 'a') as outf:
             for segment in segments:
+                westpa.rc.pstatus(f"Writing segments")
                 outf.write_segment(segment, True)
 
             # Don't need this on the first iteration (and it's not defined then)
             if n_iter > 0:
                 n_atoms = outf.topology.n_atoms
+                h5_trajectory_pointers = outf.read_data('/', 'pointer')
 
         iter_group = self.get_iter_group(n_iter)
 
         if 'trajectories' not in iter_group:
+            westpa.rc.pstatus("Trajectories does not exist")
             # print(f"trajectories not found in {iter_group.keys()} at iter {n_iter}")
 
             iter_group['trajectories'] = h5py.ExternalLink(iter_ref_rel_path, '/')
@@ -594,39 +597,64 @@ class WESTDataManager:
 
             n_segments = self.get_iter_summary()[0]
 
-            # This feels like a slightly weird way to get these, but there's not really an option
-            steps_per_seg = westpa.rc.config.get(['west', 'system', 'system_options', 'pcoord_len'])-1
+            # This feels like a slightly indirect way to get these, but this seems to be the only
+            #   place we are guaranteed to know the total number of segments in this iteration.
+            self.steps_per_seg = westpa.rc.config.get(['west', 'system', 'system_options', 'pcoord_len'])-1
+            # TODO: Magic number, and also makes it MD-specific..
             n_dims = 3
-            n_frames = steps_per_seg * n_segments
+            n_frames = self.steps_per_seg * n_segments
 
-            iter_layout = h5py.VirtualLayout(
-                shape=(n_segments, steps_per_seg, n_atoms, n_dims),
+            self.iter_layout = h5py.VirtualLayout(
+                shape=(n_segments, self.steps_per_seg, n_atoms, n_dims),
                 dtype='<f4')
 
-            iter_vsource = h5py.VirtualSource(
+            self.iter_vsource = h5py.VirtualSource(
                 '.',
                 '/coordinates',
                 shape=(n_frames, n_atoms, n_dims)
             )
 
-            for i in range(n_segments):
+            self.n_remaining_segments = n_segments-1
 
-                segment_index = i
+        # After we prepare the virtual dataset, we populate it as segments come in
+        else:
+            print("Trajectories already exists")
+
+            if n_iter == 0:
+                return
+
+            # for i in range(n_segments):
+            for i, segment in enumerate(segments):
+
+                segment_index = segment.seg_id
+
+                # TODO: Is this quite the correct way to get these?
+                #       Maybe I need to use pointer to get source_index
+                source_index = i
+                westpa.rc.pstatus(h5_trajectory_pointers)
+                source_index = h5_trajectory_pointers[i*self.steps_per_seg,1]
+
+
+                westpa.rc.pstatus(f"Placing segment with source index {source_index} at index {segment.seg_id}")
 
                 # A layout can be populated from a source file that doesn't exist yet
                 # TODO: Use the pointer or something instead of i, so these are correctly ordered
                 #   according to ID.
-                iter_layout[segment_index] = iter_vsource[
-                        i * steps_per_seg:(i + 1) * steps_per_seg
+                self.iter_layout[segment_index] = self.iter_vsource[
+                        source_index * self.steps_per_seg:(source_index + 1) * self.steps_per_seg
                     ]
+                self.n_remaining_segments -= 1
+                westpa.rc.pstatus(self.n_remaining_segments)
 
-            with h5py.File(iter_ref_h5_file, 'a') as outf:
-                # self.we_h5file.create_virtual_dataset(
-                outf.create_virtual_dataset(
-                    '/segment_trajectories',
-                    iter_layout,
-                    fillvalue=-1
-                )
+            if self.n_remaining_segments < 0:
+                westpa.rc.pstatus("Writing virtual dataset")
+                # If all the segments have been processed, create the virtual dataset
+                with h5py.File(iter_ref_h5_file, 'a') as outf:
+                    outf.create_virtual_dataset(
+                        '/sorted_segment_trajectories',
+                        self.iter_layout,
+                        fillvalue=-1
+                    )
 
     def get_basis_states(self, n_iter=None):
         '''Return a list of BasisState objects representing the basis states that are in use for iteration n_iter.'''

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -38,6 +38,7 @@ default_iter_prec = 8
 # Helper functions
 #
 
+class NoRestartError(ValueError): pass
 
 def resolve_filepath(path, constructor=h5py.File, cargs=None, ckwargs=None, **addtlkwargs):
     '''Use a combined filesystem and HDF5 path to open an HDF5 file and return the
@@ -631,7 +632,7 @@ class WESTIterationFile(HDF5TrajectoryFile):
             data = self.read_data('/restart/%d_%d' % (segment.n_iter, segment.seg_id), 'data')
             segment.data['iterh5/restart'] = data
         else:
-            raise ValueError('no restart data available for {}'.format(str(segment)))
+            raise NoRestartError('no restart data available for {}'.format(str(segment)))
 
     def write_segment(self, segment, pop=False):
         n_iter = segment.n_iter

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -38,7 +38,10 @@ default_iter_prec = 8
 # Helper functions
 #
 
-class NoRestartError(ValueError): pass
+
+class NoRestartError(ValueError):
+    pass
+
 
 def resolve_filepath(path, constructor=h5py.File, cargs=None, ckwargs=None, **addtlkwargs):
     '''Use a combined filesystem and HDF5 path to open an HDF5 file and return the

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -20,6 +20,7 @@ from westpa.core.propagators import WESTPropagator
 from westpa.core.states import BasisState, InitialState
 from westpa.core.segment import Segment
 from westpa.core.yamlcfg import check_bool
+from westpa.core.h5io import WESTIterationFile
 
 from westpa.core.trajectory import load_trajectory
 
@@ -363,6 +364,22 @@ class ExecutablePropagator(WESTPropagator):
         return (rc, rusage)
 
     def exec_child_from_child_info(self, child_info, template_args, environ):
+        """
+        Runs an executable in a child process, with a specified environment.
+
+        Parameters
+        ----------
+        child_info : dict
+            Contains keys: environ, executable, cwd, stdin, stdout, stderr
+        template_args: dict
+            Keyword arguments passed to template.format
+        environ: dict
+            Environment variables for child process
+
+        Returns
+        -------
+        (return code, resource usage) from the child process
+        """
         for (key, value) in child_info.get('environ', {}).items():
             environ[key] = self.makepath(value)
         return self.exec_child(
@@ -516,6 +533,7 @@ class ExecutablePropagator(WESTPropagator):
             shutil.rmtree(environ[self.ENV_CURRENT_SEG_DATA_REF])
             os.makedirs(environ[self.ENV_CURRENT_SEG_DATA_REF])
         if self.data_info['restart']['enabled']:
+            print(f"Preparing for seg with data ref {environ[self.ENV_CURRENT_SEG_DATA_REF]}")
             restart_writer(environ[self.ENV_CURRENT_SEG_DATA_REF], segment=segment)
 
     def setup_dataset_return(self, segment=None, subset_keys=None):
@@ -611,7 +629,6 @@ class ExecutablePropagator(WESTPropagator):
 
         westpa.rc.pstatus(f"getting pcoord for structure {struct_ref}")
 
-
         state_ref_is_h5 = 'hdf:' in struct_ref
 
         # Paths to data references can optionally be specified as hdf://<path/to/west/h5>:<iter>:<walker>.
@@ -626,18 +643,17 @@ class ExecutablePropagator(WESTPropagator):
             # Get the pcoord from the H5 file (assume it's formatted the same as this one!)
             with h5py.File(h5path, 'r') as prev_h5:
 
-                template = self.rc.config.get(['west', 'data', 'data_refs', 'iteration'])
-                # TODO: Don't require the format placeholder to be named n_iter
-                iter_group = f'iterations/iter_{iteration:08d}/pcoord'
+                # TODO: Get this in some non-hardcoded way
+                iter_group = f'iterations/iter_{iteration:08d}'
 
                 print(f"Trying to get {iter_group}")
                 h5_iter_dataset = prev_h5[iter_group]
 
                 print(f"Got {h5_iter_dataset}")
 
-                pcoord = h5_iter_dataset[seg_id][-1]
+                # Manually load pcoord
+                pcoord = h5_iter_dataset['pcoord'][seg_id][-1]
                 self.rc.pstatus(f"Got pcoord {pcoord}")
-
                 state.pcoord = pcoord
 
         else:
@@ -673,6 +689,70 @@ class ExecutablePropagator(WESTPropagator):
             initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
 
     def prepare_iteration(self, n_iter, segments):
+
+        if n_iter == 1:
+            westpa.rc.pstatus(f"Current iteration is {self.rc.get_sim_manager().n_iter}, preparing sstates")
+
+            # When a segment runs, a common first step is to link in $WEST_PARENT_DATA_REF.
+            # So, each start-state structure that's actually in use needs to be accessible in a file
+            #   via $WEST_PARENT_DATA_REF.
+
+            # That means to prepare the first iteration, we need to make sure that's populated with valid paths.
+            # This will *probably* consist of:
+            #   1. Get all initial states
+            #   2. Remove all istate/bstates, keep only sstates
+            #   3. For each, write the structure as a file to the appropriate traj_segs segment directory, OR write it
+            #       somewhere central and set $WEST_PARENT_DATA_REF (probably better)
+            istates = self.rc.get_data_manager().get_initial_states(n_iter=1)
+            bstates = self.rc.get_data_manager().get_basis_states(n_iter=1)
+
+            # These are read by update_args_env_segment.. However, that
+            self.initial_states = {istate.state_id:istate for istate in istates}
+            self.basis_states = {bstate.state_id:bstate for bstate in bstates}
+
+            for segment in segments.values():
+
+                print(f"\nProcessing segment with pcoord {segment.pcoord.flatten()[:5]}")
+
+                template_args, environ = {}, {}
+                self.update_args_env_iter(template_args, environ, segment.n_iter)
+                self.update_args_env_segment(template_args, environ, segment)
+
+                initial_state = istates[segment.initial_state_id]
+                basis_state = bstates[initial_state.basis_state_id]
+
+                #  TODO: Turbo duplicated code from get_pcoord, make a generic implementation
+                if basis_state.auxref[:4] == 'hdf:':
+                    westpa.rc.pstatus(f'\t This is an HDF-style state -- additional processing needed')
+
+                    _, h5path, iteration, seg_id = basis_state.auxref.split(':')
+                    westpa.rc.pstatus(f"\t Looking for segment {seg_id} in iteration {iteration} of h5file {h5path}")
+
+                    # Get the pcoord from the H5 file (assume it's formatted the same as this one!)
+                    with h5py.File(h5path, 'r') as prev_h5:
+                        #  TODO: Get this in some non-hardcoded way
+                        iter_group = f'iterations/iter_{int(iteration):08d}'
+                        iter_h5 = prev_h5[iter_group]['trajectories']
+
+                        with WESTIterationFile(iter_h5.file.filename) as iterh5file:
+
+                            # The segment we're looking for as the start-state is not the segment we have now -- the
+                            #   seg_id and iteration correspond to this basis/start-states seg_id and iteration in the
+                            #   simulation it was generated from.
+                            # We make a dummy segment with those, populate the restart data, then copy the restart
+                            #   data to the actual segment.
+                            bstate_segment = Segment(n_iter=iteration, seg_id=seg_id)
+                            iterh5file.read_restart(bstate_segment)
+
+                            segment.data['iterh5/restart'] = bstate_segment.data['iterh5/restart']
+
+                # This calls the restart writer
+                # Before calling this, the segment has to have segment.data['iterh5/restart'] prepared
+                # I actually don't need to manually call this (and shouldn't) because it's called in the normal flow.
+                # self.prepare_file_system(segment, environ)
+
+        westpa.rc.pstatus("*** Pre-iteration complete ***")
+
         child_info = self.exe_info.get('pre_iteration')
         if child_info and child_info['enabled']:
             try:


### PR DESCRIPTION
**Issue Number.**
N/A

## **Describe the changes made.** 

Rather than storing start state structures as files on disk, allow retrieving them from HDF5-framework datasets.

This will allow completely eliminating disk IO for start-states.

This can be implemented by optionally allowing a basis_auxref for a basis/start state to be specified like `hdf5:<path/to/hdf>:iteration:seg_id` instead of a path to a file on disk. In this case, instead of looking for a file on disk to load, a structure will be loaded from the specified dataset in that h5 file.

For example, a bstates file could look like
```
01 0.1 01
02 0.1 02
03 0.1 03
04 0.1 04
05 0.1 05
06 0.1 06
07 0.1 07
08 0.1 08
09 0.1 09
10 0.05 10
11 0.05 hdf:sstates/prev_west.h5:2:4
```
where `prev_west.h5` is an h5file from a previous WE run with the HDF5 framework. (The per-iteration H5 files linked to from that dataset must be accessible.)

This functionality will be developed for the executable propagator, since the H5 framework is only directly compatible with the executable propagator.


## **Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  

### Overall goal:
- [ ] Allow initializing a WESTPA simulation (or, equivalently, initializing a restart) using states stored in an HDF5 file, instead of written to disk.

### Checkpoints:
- [x] Allow loading basis-states directly from an HDF5 file
- [ ] Ensure compatibility with both basis-states and start-states
- [ ] Connect to restarting plugin, so it can write structures as an H5 file instead of as individual PDBs.
     Note some extra magic will have to happen here, since each restart is synthesizing multiple H5 files. Something like...
     - [ ] Make restarting plugin write out its own h5 file, which is used in place of `prev_west.h5` in the example above, and which links `cluster_id/seg_id` to `restart/run/iter/segment`. 

## **Major files changed.**  
- [x] `propagators.executable`

## **Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## **Additional context.**
N/A

