### PR TITLE
Fix MPI test skip and stabilize ZMQ shutdown test

### DIFF
--- a/tests/test_work_managers/test_mpi.py
+++ b/tests/test_work_managers/test_mpi.py
@@ -1,4 +1,7 @@
 import unittest
+import pytest
+
+pytest.importorskip("mpi4py", reason="mpi4py is required for MPI tests")
 
 from westpa.work_managers.mpi import MPIWorkManager
 

--- a/tests/test_work_managers/test_zeromq/test_work_manager.py
+++ b/tests/test_work_managers/test_zeromq/test_work_manager.py
@@ -270,19 +270,19 @@ class TestZMQWorkManagerInternalNone(ZMQTestBase, unittest.TestCase):
 
     @flaky_on_macos
     def test_shutdown_without_workers(self):
-        time.sleep(1.5)
+        time.sleep(2.0)
         assert not self.test_wm.comm_thread.is_alive()
 
     @flaky_on_macos
     def test_shutdown_without_workers_after_submission(self):
         self.test_wm.submit(identity, (1,), {})
-        time.sleep(1.5)
+        time.sleep(2.0)
         assert not self.test_wm.comm_thread.is_alive()
 
     @flaky_on_macos
     def test_shutdown_without_workers_raises_future_error(self):
         future = self.test_wm.submit(identity, (1,), {})
-        time.sleep(1.5)
+        time.sleep(2.0)
         assert isinstance(future.get_exception(), ZMQWorkerMissing)
 
 


### PR DESCRIPTION
## Summary
- skip MPI work manager tests when `mpi4py` is missing
- give ZMQ shutdown tests more time for thread cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8fbdb88c832683fbff9384bf10eb